### PR TITLE
[FIX] Allow invisible walls (with texture names of "-")

### DIFF
--- a/wad2gltf/map_reader.cpp
+++ b/wad2gltf/map_reader.cpp
@@ -65,6 +65,11 @@ void emit_face(
     std::vector<Face>& destination, const wad::WAD& wad,
     Map& map
 ) {
+    if(texture_name.is_none()) {
+        // The Unofficial Doom Specs state that "-" means not rendered, so don't generate the face
+        return;
+    }
+
     auto face = create_face(v0, v1, bottom, top);
     face.texture_index = map.get_texture_index(texture_name, wad);
 

--- a/wad2gltf/mesh.hpp
+++ b/wad2gltf/mesh.hpp
@@ -91,6 +91,9 @@ inline uint32_t Map::get_flat_index(const wad::Name& flat_name, const wad::WAD& 
     if (!flat_name.is_valid()) {
         throw std::runtime_error{ "Texture name is not valid" };
     }
+    if (flat_name.is_none()) {
+        throw std::runtime_error{ "Sector floor/ceiling name cannot be '-'." };
+    }
 
     for (auto i = 0u; i < textures.size(); i++) {
         const auto& texture = textures[i];

--- a/wad2gltf/wad_name.hpp
+++ b/wad2gltf/wad_name.hpp
@@ -30,6 +30,8 @@ namespace wad {
         std::string to_string() const;
 
         bool is_valid() const;
+
+        bool is_none() const;
     };
 
     inline bool Name::operator==(const std::string_view str) const {
@@ -58,7 +60,12 @@ namespace wad {
     }
 
     inline bool Name::is_valid() const {
-        return val[0] != '\0' && val[0] != '-';
+        return val[0] != '\0';
+    }
+
+    inline bool Name::is_none() const {
+        // The Unofficial Doom Specs state that '-' means "no texture" or transparent (not rendered)
+        return val[0] == '-' && val[1] == '\0';
     }
 }
 


### PR DESCRIPTION
The Unofficial Doom Specs state that when sidedefs use the texture name "-", that it means that the wall should be invisible, so don't generate wall faces in that case. Doom 2 MAP01 requires this change.